### PR TITLE
Potential fix for code scanning alert no. 177: Useless regular-expression character escape

### DIFF
--- a/mngWfBp6TJHYeQaEOaC0zjN2t/905590178274160401833477695303.html
+++ b/mngWfBp6TJHYeQaEOaC0zjN2t/905590178274160401833477695303.html
@@ -236,7 +236,7 @@
                 input.noWhatsApp.focus();
                 setTimeout(() => alert.noWhatsApp.empty(), 2500);
                 return false;
-            } else if (!(new RegExp("^[\-\+\ 0-9]+$", "g")).test(input.noWhatsApp.val())) {
+            } else if (!(new RegExp("^[\-+\ 0-9]+$", "g")).test(input.noWhatsApp.val())) {
                 alert.noWhatsApp.html(alertDanger("Silahkan masukkan nomor WhatsApp yang benar!"));
                 input.noWhatsApp.focus().val('');
                 setTimeout(() => alert.noWhatsApp.empty(), 2500);

--- a/mngWfBp6TJHYeQaEOaC0zjN2t/905590178274160401833477695303.html
+++ b/mngWfBp6TJHYeQaEOaC0zjN2t/905590178274160401833477695303.html
@@ -236,7 +236,7 @@
                 input.noWhatsApp.focus();
                 setTimeout(() => alert.noWhatsApp.empty(), 2500);
                 return false;
-            } else if (!(new RegExp("^[\-+\ 0-9]+$", "g")).test(input.noWhatsApp.val())) {
+            } else if (!(new RegExp("^[+\ 0-9-]+$", "g")).test(input.noWhatsApp.val())) {
                 alert.noWhatsApp.html(alertDanger("Silahkan masukkan nomor WhatsApp yang benar!"));
                 input.noWhatsApp.focus().val('');
                 setTimeout(() => alert.noWhatsApp.empty(), 2500);


### PR DESCRIPTION
Potential fix for [https://github.com/IRMABaitussalam/irmabaitussalam.github.io/security/code-scanning/177](https://github.com/IRMABaitussalam/irmabaitussalam.github.io/security/code-scanning/177)

To fix the problem, we need to remove the unnecessary escape sequence `\-` from the regular expression. This will not change the functionality of the regular expression but will make the code cleaner and more readable.

- Locate the regular expression on line 239.
- Remove the unnecessary escape sequence `\-` from the regular expression.
- Ensure that the regular expression still matches phone numbers that may include `-`, `+`, spaces, and digits.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
