### PR TITLE
Potential fix for code scanning alert no. 175: Useless regular-expression character escape

### DIFF
--- a/kuesioner.html
+++ b/kuesioner.html
@@ -225,7 +225,7 @@
                 input.noWhatsApp.focus();
                 setTimeout(() => alert.noWhatsApp.empty(), 2500);
                 return false;
-            } else if (!(new RegExp("^[\-\+\ 0-9]+$", "g")).test(input.noWhatsApp.val())) {
+            } else if (!(new RegExp("^[\-+\ 0-9]+$", "g")).test(input.noWhatsApp.val())) {
                 alert.noWhatsApp.html(alertDanger("Silahkan masukkan nomor WhatsApp yang benar!"));
                 input.noWhatsApp.focus().val('');
                 setTimeout(() => alert.noWhatsApp.empty(), 2500);

--- a/kuesioner.html
+++ b/kuesioner.html
@@ -225,7 +225,7 @@
                 input.noWhatsApp.focus();
                 setTimeout(() => alert.noWhatsApp.empty(), 2500);
                 return false;
-            } else if (!(new RegExp("^[\-+\ 0-9]+$", "g")).test(input.noWhatsApp.val())) {
+            } else if (!(new RegExp("^[\-+ 0-9]+$", "g")).test(input.noWhatsApp.val())) {
                 alert.noWhatsApp.html(alertDanger("Silahkan masukkan nomor WhatsApp yang benar!"));
                 input.noWhatsApp.focus().val('');
                 setTimeout(() => alert.noWhatsApp.empty(), 2500);


### PR DESCRIPTION
Potential fix for [https://github.com/IRMABaitussalam/irmabaitussalam.github.io/security/code-scanning/175](https://github.com/IRMABaitussalam/irmabaitussalam.github.io/security/code-scanning/175)

To fix the problem, we need to remove the unnecessary escape sequence `\-` from the regular expression. The correct way to represent a hyphen character in a character class is simply `-`. This change will not affect the functionality of the regular expression but will make the code cleaner and more understandable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
