### PR TITLE
Potential fix for code scanning alert no. 189: DOM text reinterpreted as HTML

### DIFF
--- a/quotes/index.html
+++ b/quotes/index.html
@@ -107,6 +107,15 @@
   <!-- Custom JS -->
   <script src="../js/theme.js"></script>
   <script>
+    function escapeHtml(unsafe) {
+      return unsafe
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+    }
+
     $(document).ready(function() {
       $('#currentYear').text(new Date().getFullYear());
       $('#navbarNav').on('show.bs.collapse', function () {
@@ -155,7 +164,7 @@
         if (found) {
           $("#no-results").addClass("d-none");
         } else {
-          $("#no-results").html(`Quotes dengan kata kunci "<span class="fw-bold">${$(this).val()}</span>" tidak ditemukan.`);
+          $("#no-results").html(`Quotes dengan kata kunci "<span class="fw-bold">${escapeHtml($(this).val())}</span>" tidak ditemukan.`);
           $("#no-results").removeClass("d-none");
         }
       });


### PR DESCRIPTION
Potential fix for [https://github.com/IRMABaitussalam/irmabaitussalam.github.io/security/code-scanning/189](https://github.com/IRMABaitussalam/irmabaitussalam.github.io/security/code-scanning/189)

To fix the problem, we need to ensure that any user input is properly escaped before being inserted into the HTML. This can be achieved by using a function that escapes HTML special characters, thereby preventing any potential XSS attacks. We will create a utility function to escape HTML characters and use it to sanitize the user input before embedding it in the HTML string.

- Create a function to escape HTML special characters.
- Use this function to sanitize the user input from `$(this).val()` before embedding it in the HTML string on line 158.
- Ensure the fix is applied within the same script block to maintain existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
